### PR TITLE
specifed faker version to 2.2.1 to prevent future errors

### DIFF
--- a/mock_filewatcher.gemspec
+++ b/mock_filewatcher.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'faker'
+  spec.add_runtime_dependency 'faker', "2.2.1"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", ">= 12.3.3"


### PR DESCRIPTION
was previously using the latest version of Faker (2.13.0) which was creating issues with MMS and Ingest Reporter