### PR TITLE
Use keyword argument for Faker::Date.backward

### DIFF
--- a/lib/mock_filewatcher.rb
+++ b/lib/mock_filewatcher.rb
@@ -112,7 +112,7 @@ private
         :contentNotes     => [Faker::Lorem.sentences(number: rand(2)+1).join(" "), nil ].sample,
         :accessNote       => [Faker::Lorem.sentences(number: rand(2)+1).join(" "), nil ].sample,
         :duration         => ["00:16:25:23", "01:1#{rand{8}+1}:25:23", "01:16:25:#{rand{9}}#{rand{9}}"].sample,
-        :dateCaptured     => Faker::Date.backward(1000).strftime("%-m/%d/%y"),
+        :dateCaptured     => Faker::Date.backward(days: 1000).strftime("%-m/%d/%y"),
         :projectIdentifier => "#{Faker::Lorem.words(number: 1).first}.xls",
         :formerClassmark   => "* #{('A'..'Z').to_a.shuffle[0..4].join} #{('1'..'9').to_a.shuffle[0..2].join}"
         }


### PR DESCRIPTION
# Allo @emu47!

_I come back to you now at the turn of the tide...._

This removes deprecation warnings like:

```
/lib/mock_filewatcher.rb:18: Passing numberwith the 1st argument ofLorem.wordsis deprecated. Use keyword argument likeLorem.words(number: ...) instead.
```

This fixes the issue raised in https://github.com/NYPL/mock_filewatcher/issues/4

## Testing

This works locally for me when running in `./bin/console`

```
2.3.4 :001 > my_mock_file_watcher = MockFilewatcher.new
 => #<MockFilewatcher:0x007fc05d184e60 @bag_path="/bags/cupiditate/numquam", @file_name="iustoet.mov", @options={:message_version=>"1.0", :bag_disposition=>"video"}>

2.3.4 :002 > my_mock_file_watcher.create_fake_message
 => {:UUID=>"2c3b35b8-f43e-4878-a996-8b8a58eb5c09", :assetFileName=>"iustoet.mov", :definition=>"sd", :isInMMS=>false, :width=>893, :height=>651, :fileSize=>125973, :pathToBag=>"/bags/cupiditate/numquam", :checksum=>"798ed7d4ee7138d49b8828958048130a", :metadata=>{:...snip!
```

## Finally

Stay golden.