### PR TITLE
DR-2119 Fix bnumber generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+*.swp
+*.swo

--- a/lib/mock_filewatcher.rb
+++ b/lib/mock_filewatcher.rb
@@ -60,7 +60,7 @@ private
       @message[:metadata][:nonCMSID] = "#{(1...10000).to_a.sample}"
       @message[:metadata][:nonCMSItemID] = "#{(1...10000).to_a.sample}"
       @message[:metadata][:cmsCollectionID]= "#{(1...10000).to_a.sample}"
-      @message[:metadata][:bnumber] = "b#{(10000000...999999999).to_a.sample}"
+      @message[:metadata][:bnumber] = "b#{(10000000...10010000).to_a.sample}"
 
       # Values have changed since v 1.0
       note_proc = Proc.new{ Faker::Lorem.sentences(number: rand(2)+1).join(" ") }

--- a/lib/mock_filewatcher.rb
+++ b/lib/mock_filewatcher.rb
@@ -60,7 +60,7 @@ private
       @message[:metadata][:nonCMSID] = "#{(1...10000).to_a.sample}"
       @message[:metadata][:nonCMSItemID] = "#{(1...10000).to_a.sample}"
       @message[:metadata][:cmsCollectionID]= "#{(1...10000).to_a.sample}"
-      @message[:metadata][:bnumber] = "B-#{(1...10000).to_a.sample}"
+      @message[:metadata][:bnumber] = "b#{(10000000...999999999).to_a.sample}"
 
       # Values have changed since v 1.0
       note_proc = Proc.new{ Faker::Lorem.sentences(number: rand(2)+1).join(" ") }

--- a/lib/mock_filewatcher/version.rb
+++ b/lib/mock_filewatcher/version.rb
@@ -1,3 +1,3 @@
 class MockFilewatcher
-  VERSION = "0.1.6"
+  VERSION = "0.1.10"
 end


### PR DESCRIPTION
## Jira Tickets ##
[MMS: Validate bnumber](https://jira.nypl.org/browse/DR-2119)

## Things Done ##
- Make the mock bnumber generator generate valid bnumber values (b + 8-9 digits)
- Bump the gem version to v.0.1.10

## How to Test ##
- Rspecs should pass again in https://github.com/NYPL/mms/pull/415